### PR TITLE
Support for pulling status from lists

### DIFF
--- a/wp-twitter-widget.php
+++ b/wp-twitter-widget.php
@@ -1047,7 +1047,7 @@ class wpTwitterWidget extends RangePlugin {
 			$user = array_shift( explode( '::', $widgetOptions['list'] ) );
 			$this->_wp_twitter_oauth->set_token( $this->_settings['twp-authed-users'][strtolower( $user )] );
 
-			$response = $this->_wp_twitter_oauth->send_authed_request( 'statuses/user_timeline', 'GET', $parameters );
+			$response = $this->_wp_twitter_oauth->send_authed_request( 'lists/statuses', 'GET', $parameters );
 			if ( ! is_wp_error( $response ) )
 				return $response;
 		}


### PR DESCRIPTION
Couple of threads on http://wordpress.org/support with people commenting that they don't seem to be able to display tweets from lists - eg http://wordpress.org/support/topic/how-does-one-show-other-people-tweets-list-or-other-account?replies=5

Looking through the code the cause appears to be here - if there's no screen_name specified but there is a list_id then it gets the user, sets the appropriate oauth token but then requests the user's timeline instead of the list data.
