### PR TITLE
Fix weird instance where $decoded_response was actually a string.

### DIFF
--- a/lib/wp-twitter.php
+++ b/lib/wp-twitter.php
@@ -117,7 +117,7 @@ class wpTwitter {
 
 		if ( !is_wp_error( $resp ) && $resp['response']['code'] >= 200 && $resp['response']['code'] < 300 ) {
 			$decoded_response = json_decode( $resp['body'] );
-			if ( empty( $decoded_response ) && ! empty( $resp['body'] ) )
+			if ( ! is_array( $decoded_response ) && ! empty( $resp['body'] ) )
 				$decoded_response = wp_parse_args( $resp['body'] );
 			return $decoded_response;
 		} else {


### PR DESCRIPTION
Fix weird instance where $decoded_response was actually a string. 

I'm not 100% sure of the underlying reason but $decoded_response was being returned as a string like:

```
oauth_token=D7AfkOc7nSHfV3r4UEq5LgqV5WBISOlrjlziDWlNg&oauth_token_secret=FOP11727jWw5CTuFIjkd85mVE3GxcuMqpX0thVQ2njQ&oauth_callback_confirmed=true
```

And then because the string was not validating as empty it'd never hit `wp_parse_args( $resp['body'] );` and be converted into an array.

Might solve a lot of peoples issues in the forums where they can't authenticate
