### PR TITLE
Fix for long retweets, number of tweets displayed and formatting of tweet intent links

### DIFF
--- a/wp-twitter-widget.php
+++ b/wp-twitter-widget.php
@@ -813,7 +813,13 @@ class wpTwitterWidget {
 			foreach ( $tweets as $tweet ) {
 				// Set our "ago" string which converts the date to "# ___(s) ago"
 				$tweet->ago = $this->_timeSince( strtotime( $tweet->created_at ), $args['showts'], $args['dateFormat'] );
-				$entryContent = apply_filters( 'widget_twitter_content', $tweet->text, $tweet );
+				// Use full text of retweets
+				if ( isset($tweet->retweeted_status) ) {
+					$tweet_text = "RT @".$tweet->retweeted_status->user->screen_name.":".$tweet->retweeted_status->text;
+				} else {
+					$tweet_text = $tweet->text;
+				}
+				$entryContent = apply_filters( 'widget_twitter_content', $tweet_text, $tweet );
 				$widgetContent .= '<li>';
 				$widgetContent .= "<span class='entry-content'>{$entryContent}</span>";
 				$widgetContent .= " <span class='entry-meta'>";

--- a/wp-twitter-widget.php
+++ b/wp-twitter-widget.php
@@ -823,7 +823,7 @@ class wpTwitterWidget {
 				$widgetContent .= '<li>';
 				$widgetContent .= "<span class='entry-content'>{$entryContent}</span>";
 				$widgetContent .= " <span class='entry-meta'>";
-				$widgetContent .= "<span class='time-meta'>";
+				$widgetContent .= "<br><span class='time-meta'>";
 				$linkAttrs = array(
 					'href'	=> "http://twitter.com/{$tweet->user->screen_name}/statuses/{$tweet->id_str}"
 				);
@@ -847,7 +847,7 @@ class wpTwitterWidget {
  				$widgetContent .= '</span>';
 
 				if ( 'true' == $args['showintents'] ) {
-					$widgetContent .= ' <span class="intent-meta">';
+					$widgetContent .= '<br><span class="intent-meta">';
 					$lang = $this->_getTwitterLang();
 					if ( !empty( $lang ) )
 						$linkAttrs['data-lang'] = $lang;
@@ -857,12 +857,14 @@ class wpTwitterWidget {
 					$linkAttrs['class'] = 'in-reply-to';
 					$linkAttrs['title'] = $linkText;
 					$widgetContent .= $this->_buildLink( $linkText, $linkAttrs );
+					$widgetContent .= '&nbsp;|&nbsp;';
 
 					$linkText = __( 'Retweet', 'twitter-widget-pro' );
 					$linkAttrs['href'] = "http://twitter.com/intent/retweet?tweet_id={$tweet->id_str}";
 					$linkAttrs['class'] = 'retweet';
 					$linkAttrs['title'] = $linkText;
 					$widgetContent .= $this->_buildLink( $linkText, $linkAttrs );
+					$widgetContent .= '&nbsp;|&nbsp;';
 
 					$linkText = __( 'Favorite', 'twitter-widget-pro' );
 					$linkAttrs['href'] = "http://twitter.com/intent/favorite?tweet_id={$tweet->id_str}";

--- a/wp-twitter-widget.php
+++ b/wp-twitter-widget.php
@@ -781,10 +781,9 @@ class wpTwitterWidget {
 		if ( 'true' == $args['targetBlank'] )
 			add_filter( 'widget_twitter_link_attributes', array( $this, 'targetBlank' ) );
 
-		// Validate our options
-		$args['items'] = (int) $args['items'];
-		if ( $args['items'] < 1 || 20 < $args['items'] )
-			$args['items'] = 10;
+		$number_to_display = (int) $args['items'];
+		// Number requested includes retweets and replies, whether widget is configured to display them or not
+		$args['items'] = 20;
 
 		if ( !isset( $args['showts'] ) )
 			$args['showts'] = 86400;
@@ -868,7 +867,7 @@ class wpTwitterWidget {
 				}
 				$widgetContent .= '</li>';
 
-				if ( ++$count >= $args['items'] )
+				if ( ++$count >= $number_to_display )
 					break;
 			}
 		}


### PR DESCRIPTION
This PR addresses three problems I and others have had with this widget -
- the number of tweets displayed is less than the configured number if the widget is also configured to exclude either retweets or replies. The twitter API treats the requested number as the total including retweets and replies regardless of whether you actually request them.
- Long retweets are truncated with an ellipsis if they exceed 140 characters _after_ prepending the attribution.
- The tweet intent links are displayed with no spacing between them.
  I have also moved the intent links and the timestamp link onto separate lines.
